### PR TITLE
Replace non-breaking space characters with plain spaces

### DIFF
--- a/include/archi/utils.h
+++ b/include/archi/utils.h
@@ -20,10 +20,10 @@
 
 
 #define __ARCHI_DEF_REG_STR(x) #x
-#define _ARCHI_DEF_REG_MASK(x) __ARCHI_DEF_REG_STR(x ## _MASK ARCHI_REG_MASK(x ## _BIT, x ## _BITS))
+#define _ARCHI_DEF_REG_MASK(x) __ARCHI_DEF_REG_STR(x ## _MASK ARCHI_REG_MASK(x ## _BIT, x ## _BITS))
 #define ARCHI_DEF_REG_MASK(x) _ARCHI_DEF_REF_MASK(x)
 
-#define _ARCHI_DEF_REG_VALUE(x, vname, val) __ARCHI_DEF_REG_STR(x ## _ ## vname  (val << (x ## _BIT)))
+#define _ARCHI_DEF_REG_VALUE(x, vname, val) __ARCHI_DEF_REG_STR(x ## _ ## vname  (val << (x ## _BIT)))
 #define ARCHI_DEF_REG_VALUE(x, vname, val) _ARCHI_DEF_REG_VALUE(x, vname, val)
 
 


### PR DESCRIPTION
It looks like gcc is ok with 0xC2 0xA0 symbol in the code, but cppcheck can't parse any code that includes archi/utils.h because of non-standard space characters.
This fixes the following cppcheck error:

>  The code contains unhandled character(s) (character code=194). Neither unicode nor extended ascii is supported.
