### PR TITLE
Fixed code points in utils.h which fail the build under GCC 10 / 11

### DIFF
--- a/include/archi/utils.h
+++ b/include/archi/utils.h
@@ -20,10 +20,10 @@
 
 
 #define __ARCHI_DEF_REG_STR(x) #x
-#define _ARCHI_DEF_REG_MASK(x) __ARCHI_DEF_REG_STR(x ## _MASK ARCHI_REG_MASK(x ## _BIT, x ## _BITS))
+#define _ARCHI_DEF_REG_MASK(x) __ARCHI_DEF_REG_STR(x ## _MASK ARCHI_REG_MASK(x ## _BIT, x ## _BITS))
 #define ARCHI_DEF_REG_MASK(x) _ARCHI_DEF_REF_MASK(x)
 
-#define _ARCHI_DEF_REG_VALUE(x, vname, val) __ARCHI_DEF_REG_STR(x ## _ ## vname  (val << (x ## _BIT)))
+#define _ARCHI_DEF_REG_VALUE(x, vname, val) __ARCHI_DEF_REG_STR(x ## _ ## vname  (val << (x ## _BIT)))
 #define ARCHI_DEF_REG_VALUE(x, vname, val) _ARCHI_DEF_REG_VALUE(x, vname, val)
 
 


### PR DESCRIPTION
This pull request fixes pulp-platform/pulpissimo#186 where the pulp-sdk fails to build under modern GCC versions due to the forbidden special space characters.